### PR TITLE
Fix five months to seconds calculation

### DIFF
--- a/backend/src/main/java/de/otto/platform/gitactionboard/config/security/GithubAuthenticationSuccessHandler.java
+++ b/backend/src/main/java/de/otto/platform/gitactionboard/config/security/GithubAuthenticationSuccessHandler.java
@@ -40,7 +40,7 @@ public class GithubAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
   private static final int ONE_DAY = 60 * 60 * 24;
   private static final int SEVEN_HOURS = 60 * 60 * 7;
-  private static final int FIVE_MONTHS = 60 * 60 * 5 * 30;
+  private static final int FIVE_MONTHS = 60 * 60 * 24 * 30 * 5;
 
   private final OAuth2AuthorizedClientService clientService;
   private final String contextPath;

--- a/backend/src/test/java/de/otto/platform/gitactionboard/config/security/GithubAuthenticationSuccessHandlerTest.java
+++ b/backend/src/test/java/de/otto/platform/gitactionboard/config/security/GithubAuthenticationSuccessHandlerTest.java
@@ -47,7 +47,7 @@ class GithubAuthenticationSuccessHandlerTest {
 
   private static final int ONE_DAY = 60 * 60 * 24;
   private static final int SEVEN_HOURS = 60 * 60 * 7;
-  private static final int FIVE_MONTHS = 60 * 60 * 5 * 30;
+  private static final int FIVE_MONTHS = 60 * 60 * 24 * 30 * 5;
 
   private GithubAuthenticationSuccessHandler authenticationSuccessHandler;
 


### PR DESCRIPTION
There was a bug in calculation of how many seconds there are in five month. This led to the refresh token lifetime being only appr 6 days instead of 5 month