### PR TITLE
Add "Content-Length" in HTTP POST request header to fix notifications to MS Teams workflows

### DIFF
--- a/backend/src/main/java/de/otto/platform/gitactionboard/adapters/service/notifications/TeamsWebHookNotificationConnector.java
+++ b/backend/src/main/java/de/otto/platform/gitactionboard/adapters/service/notifications/TeamsWebHookNotificationConnector.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
@@ -25,8 +27,11 @@ public class TeamsWebHookNotificationConnector implements NotificationConnector 
 
   @Autowired
   public TeamsWebHookNotificationConnector(
-      RestTemplateBuilder restTemplateBuilder,
+      RestTemplateBuilder builder,
       @Value("${MS_TEAMS_NOTIFICATIONS_WEB_HOOK_URL}") String webHookUrl) {
+    final ClientHttpRequestFactory requestFactory = builder.buildRequestFactory();
+    final RestTemplateBuilder restTemplateBuilder =
+        builder.requestFactory(() -> new BufferingClientHttpRequestFactory(requestFactory));
     this.restTemplate = restTemplateBuilder.build();
     this.webHookUrl = webHookUrl;
   }

--- a/backend/src/main/java/de/otto/platform/gitactionboard/adapters/service/notifications/TeamsWebHookNotificationConnector.java
+++ b/backend/src/main/java/de/otto/platform/gitactionboard/adapters/service/notifications/TeamsWebHookNotificationConnector.java
@@ -27,12 +27,13 @@ public class TeamsWebHookNotificationConnector implements NotificationConnector 
 
   @Autowired
   public TeamsWebHookNotificationConnector(
-      RestTemplateBuilder builder,
+      RestTemplateBuilder restTemplateBuilder,
       @Value("${MS_TEAMS_NOTIFICATIONS_WEB_HOOK_URL}") String webHookUrl) {
-    final ClientHttpRequestFactory requestFactory = builder.buildRequestFactory();
-    final RestTemplateBuilder restTemplateBuilder =
-        builder.requestFactory(() -> new BufferingClientHttpRequestFactory(requestFactory));
-    this.restTemplate = restTemplateBuilder.build();
+    final ClientHttpRequestFactory requestFactory = restTemplateBuilder.buildRequestFactory();
+    this.restTemplate =
+        restTemplateBuilder
+            .requestFactory(() -> new BufferingClientHttpRequestFactory(requestFactory))
+            .build();
     this.webHookUrl = webHookUrl;
   }
 


### PR DESCRIPTION
From Spring >=6.1 the "Content-Length" header is no longer set by default when using RestTemplate to reduce memory usage. As a result, "Transfer-Encoding: chunked" is used and webhooks in MS Teams workflows do not receive the request body for requests with type application/JSON. To reenable the buffering of request bodies like before (thus setting "the Content-Length" header again), the ClientHttpRequestFactory can be wrapped in a BufferingClientHttpRequestFactory.